### PR TITLE
Skip BOM/ZWNBSP character for C#

### DIFF
--- a/pmd-cs/src/main/antlr4/net/sourceforge/pmd/lang/cs/ast/CSharpLexer.g4
+++ b/pmd-cs/src/main/antlr4/net/sourceforge/pmd/lang/cs/ast/CSharpLexer.g4
@@ -16,7 +16,8 @@ private Stack<Integer> curlyLevels = new Stack<Integer>();
 private boolean verbatium;
 }
 
-BYTE_ORDER_MARK: '\u00EF\u00BB\u00BF';
+BYTE_ORDER_MARK: '\u00EF\u00BB\u00BF' { skip(); };
+BOM : '\uFEFF' { skip(); };
 
 SINGLE_LINE_DOC_COMMENT: '///' InputCharacter*    -> channel(COMMENTS_CHANNEL);
 EMPTY_DELIMITED_DOC_COMMENT: '/***/'              -> channel(COMMENTS_CHANNEL);

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexerTest.java
@@ -101,6 +101,11 @@ class CsCpdLexerTest extends CpdTextComparisonTest {
         doTest("attributes", "_ignored", skipAttributes());
     }
 
+    @Test
+    void testBomIsSkipped() {
+        doTest("unexpectedbom");
+    }
+
     private LanguagePropertyConfig ignoreUsings() {
         return properties(true, false, false);
     }

--- a/pmd-cs/src/test/resources/net/sourceforge/pmd/lang/cs/cpd/testdata/unexpectedbom.cs
+++ b/pmd-cs/src/test/resources/net/sourceforge/pmd/lang/cs/cpd/testdata/unexpectedbom.cs
@@ -1,0 +1,4 @@
+public class SampleClass
+{
+    // This file contains a zwnbsp
+}﻿

--- a/pmd-cs/src/test/resources/net/sourceforge/pmd/lang/cs/cpd/testdata/unexpectedbom.txt
+++ b/pmd-cs/src/test/resources/net/sourceforge/pmd/lang/cs/cpd/testdata/unexpectedbom.txt
@@ -1,0 +1,10 @@
+    [Image] or [Truncated image[            Bcol      Ecol
+L1
+    [public]                                1         7
+    [class]                                 8         13
+    [SampleClass]                           14        25
+L2
+    [{]                                     1         2
+L4
+    [}]                                     1         2
+EOF


### PR DESCRIPTION
See  [#35203](https://redmine.tiobe.com/issues/35203). This PR brings the change to skip BOM characters in C# files forward to CPD 7.6.0.

Also: added unit test.